### PR TITLE
Changed color picker implementation to avoid crash in XCode 6.4

### DIFF
--- a/HighlightSelectedString/HighlightSelectedString.h
+++ b/HighlightSelectedString/HighlightSelectedString.h
@@ -8,14 +8,8 @@
 
 #import <AppKit/AppKit.h>
 
-static char extrnPro;
-
 @interface HighlightSelectedString : NSObject
 
 + (instancetype)sharedPlugin;
-
-@end
-
-@interface HighlightColorPanel : NSColorPanel
 
 @end


### PR DESCRIPTION
Changed color picker implementation to one from https://github.com/limejelly/Backlight-for-XCode.
It prevents crashing of XCode 6.4 when plugin is enabled and changing tab in color picker displayed by Interface Builder when user clicks on color attribute of object to change it.
